### PR TITLE
Fix syntax for add_action().

### DIFF
--- a/include/Check_Email_Notify_Tab.php
+++ b/include/Check_Email_Notify_Tab.php
@@ -18,7 +18,7 @@ class Check_Email_Notify_Tab
 	{
 		add_action('init', array($this, 'init'));
 		add_action('admin_enqueue_scripts', array($this, 'checkemail_assets_notify'));
-		add_action('wp_mail_failed', array($this, 'handle_failed_email', 10, 1));
+		add_action('wp_mail_failed', array($this, 'handle_failed_email'), 10, 1);
 	}
 
 	public function handle_failed_email($wp_error) {


### PR DESCRIPTION
Previously: #136, #132.

Your codebase currently has the following:

```php
		add_action('wp_mail_failed', array($this, 'handle_failed_email', 10, 1));
```

This triggers a fatal error, because when you pass an array to the second param of `add_action()` (internally, `call_user_func_array()`), it's expected to have just two members. You've placed the close parenthesis incorrectly, so that `10` and `1` are members of this array, instead of params for `add_action()`. See attached.

Strictly speaking, you could simply drop the `10` and `1` since they're both default values.

I glanced over the rest of the codebase and it looks like this is the only instance of the problem.