### PR TITLE
[BUGFIX] Add scopeSeparator to Auth configuration

### DIFF
--- a/include/Core/Auth.php
+++ b/include/Core/Auth.php
@@ -93,6 +93,7 @@ class Auth
 				'urlAccessToken'          => $access_token_url,
 				'urlResourceOwnerDetails' => $resource_owner_details_url,
 				'scopes'                  => 'openid profile User.Read Mail.Read Mail.Send',
+				'scopeSeparator' 		  => ' ',
 			]
 		);
 


### PR DESCRIPTION
Define a space as seperator as stated in the official [MS Docs](https://learn.microsoft.com/en-us/graph/auth-v2-user?tabs=http#parameters-1)

Without this param, commas are used for seperation, which breaks the user auth flow