### PR TITLE
Prevent default action on check_email_remove_outlook click

### DIFF
--- a/assets/js/admin/checkemail.js
+++ b/assets/js/admin/checkemail.js
@@ -280,6 +280,7 @@
 
   $(document).on('click', '#check_email_remove_outlook', function(e){
     t = jQuery(this);
+    e.preventDefault();
     var ajaxurl = checkemail_data.ajax_url;
     var nonce = checkemail_data.ck_mail_security_nonce;
     jQuery.ajax({


### PR DESCRIPTION
The missing preventDefault forces the page to reload, before the ajax request fullfills, which leads to the non removeing of the authentication.